### PR TITLE
Regularly send scrape request to trackers

### DIFF
--- a/src/pyrocore/data/config/rtorrent-0.8.6.rc
+++ b/src/pyrocore/data/config/rtorrent-0.8.6.rc
@@ -115,10 +115,7 @@ method.insert = d.last_scrape.send_set, simple, "d.tracker.send_scrape=0;d.last_
 method.insert = d.last_scrape.check_elapsed, simple|private, "branch={(elapsed.greater,$d.custom=tm_last_scrape,$argument.0=),d.last_scrape.send_set=}"
 # helper method: checks for non-existing/empty custom field to be able to test its validity later
 method.insert = d.last_scrape.check, simple|private, "branch={d.custom=tm_last_scrape,d.last_scrape.check_elapsed=$argument.0=,d.last_scrape.send_set=}"
-# helper method: decides whether a torrent transferring data or not
-method.insert = d.transferring.check, simple|private, "or={d.up.rate=,d.down.rate=}"
 # sets custom field (tm_last_scrape) to current time only for torrents just has been added (skips setting time on purpose when rtorrent started)
 method.set_key = event.download.inserted_new, last_scrape_i, "d.last_scrape.set="
 # check for update every 5 minutes (300 sec) and update scrape info for transferring torrents in every 10 minutes (600-20=580 sec) and for non-transferring ones in every 12 hours (43200-20=43180 sec)
-schedule2 = last_scrape_t, 300, 300, "d.multicall2=main,\"branch=$d.transferring.check=,d.last_scrape.check=580,d.last_scrape.check=43180\""
-
+schedule2 = last_scrape_t, 300, 300, "d.multicall2=main,\"branch=\\\"or={d.up.rate=,d.down.rate=}\\\",d.last_scrape.check=580,d.last_scrape.check=43180\""

--- a/src/pyrocore/data/config/rtorrent-0.8.6.rc
+++ b/src/pyrocore/data/config/rtorrent-0.8.6.rc
@@ -102,6 +102,9 @@ branch=pyro.extended=,"schedule = bind_pyrotorque,0,0,\"ui.bind_key=download_lis
 # TORQUE: Daemon watchdog
 system.method.insert = pyro.watchdog,simple|private,"execute_nothrow=bash,-c,\"$cat=\\\"test ! -f \\\",$argument.0=,\\\"/run/pyrotorque || \\\",$pyro.bin_dir=,\\\"pyrotorque --cron \\\",$argument.1=\""
 
+
+### begin: Sending scrape requests ###
+
 # Regularly update scrape information for all torrents (even stopped ones), it won't affect the operation of rtorrent, but nice to have these values updated.
 # This info is only updated when rtorrent starts or a torrent is added by default.
 # Try to balance calls to not fire them up at the same time (since multiscraping isn't implemented in libtorrent). Check for update every 5 minutes and distinguish between 2 groups:
@@ -122,3 +125,5 @@ schedule2 = last_scrape_t, 300, 300, "d.multicall2=main,\"branch=\\\"or={d.up.ra
 
 # UI/KEY: Bind "#" to send scrape request manually
 branch=pyro.extended=,"schedule2 = bind_send_scrape,0,0,\"ui.bind_key=download_list,#,d.last_scrape.send_set=\""
+
+### end: Sending scrape requests ###

--- a/src/pyrocore/data/config/rtorrent-0.8.6.rc
+++ b/src/pyrocore/data/config/rtorrent-0.8.6.rc
@@ -101,3 +101,24 @@ branch=pyro.extended=,"schedule = bind_pyrotorque,0,0,\"ui.bind_key=download_lis
 
 # TORQUE: Daemon watchdog
 system.method.insert = pyro.watchdog,simple|private,"execute_nothrow=bash,-c,\"$cat=\\\"test ! -f \\\",$argument.0=,\\\"/run/pyrotorque || \\\",$pyro.bin_dir=,\\\"pyrotorque --cron \\\",$argument.1=\""
+
+# Regularly update scrape information for all torrents (even stopped ones), it won't affect the operation of rtorrent, but nice to have these values updated.
+# This info is only updated when rtorrent starts or a torrent is added by default.
+# Try to balance calls to not fire them up at the same time (since multiscraping isn't implemented in libtorrent). Check for update every 5 minutes and distinguish between 2 groups:
+#   - transferring (uploading and/or downloading) torrents: update in every 10 minutes
+#   - non-transferring torrents: update in every 12 hours
+# helper method: sets current time in a custom field (tm_last_scrape) and saves session
+method.insert = d.last_scrape.set, simple|private, "d.custom.set=tm_last_scrape,$cat=$system.time=; d.save_full_session="
+# helper method: sends the scrape request and sets the tm_last_scrape timestamp and saves session
+method.insert = d.last_scrape.send_set, simple, "d.tracker.send_scrape=0;d.last_scrape.set="
+# helper method: decides whether the required time interval (with the help of an argument) has passed and if so calls the above method
+method.insert = d.last_scrape.check_elapsed, simple|private, "branch={(elapsed.greater,$d.custom=tm_last_scrape,$argument.0=),d.last_scrape.send_set=}"
+# helper method: checks for non-existing/empty custom field to be able to test its validity later
+method.insert = d.last_scrape.check, simple|private, "branch={d.custom=tm_last_scrape,d.last_scrape.check_elapsed=$argument.0=,d.last_scrape.send_set=}"
+# helper method: decides whether a torrent transferring data or not
+method.insert = d.transferring.check, simple|private, "or={d.up.rate=,d.down.rate=}"
+# sets custom field (tm_last_scrape) to current time only for torrents just has been added (skips setting time on purpose when rtorrent started)
+method.set_key = event.download.inserted_new, last_scrape_i, "d.last_scrape.set="
+# check for update every 5 minutes (300 sec) and update scrape info for transferring torrents in every 10 minutes (600-20=580 sec) and for non-transferring ones in every 12 hours (43200-20=43180 sec)
+schedule2 = last_scrape_t, 300, 300, "d.multicall2=main,\"branch=$d.transferring.check=,d.last_scrape.check=580,d.last_scrape.check=43180\""
+

--- a/src/pyrocore/data/config/rtorrent-0.8.6.rc
+++ b/src/pyrocore/data/config/rtorrent-0.8.6.rc
@@ -119,3 +119,6 @@ method.insert = d.last_scrape.check, simple|private, "branch={d.custom=tm_last_s
 method.set_key = event.download.inserted_new, last_scrape_i, "d.last_scrape.set="
 # check for update every 5 minutes (300 sec) and update scrape info for transferring torrents in every 10 minutes (600-20=580 sec) and for non-transferring ones in every 12 hours (43200-20=43180 sec)
 schedule2 = last_scrape_t, 300, 300, "d.multicall2=main,\"branch=\\\"or={d.up.rate=,d.down.rate=}\\\",d.last_scrape.check=580,d.last_scrape.check=43180\""
+
+# UI/KEY: Bind "#" to send scrape request manually
+branch=pyro.extended=,"schedule2 = bind_send_scrape,0,0,\"ui.bind_key=download_list,#,d.last_scrape.send_set=\""


### PR DESCRIPTION
See this issue for more info: https://github.com/chros73/pyrocore/issues/2

Note! It's written in newer 0.9.6 coding style!

Edit: 
Bind key `#` to send scrape request manually for any torrent. (This key should not be easily accessible.) (See https://github.com/chros73/pyrocore/issues/3)
