### PR TITLE
Adding ability to use tm_downloaded timestamp custom variable in rtorrent config

### DIFF
--- a/src/pyrocore/data/config/rtorrent-0.8.6.rc
+++ b/src/pyrocore/data/config/rtorrent-0.8.6.rc
@@ -40,9 +40,10 @@ system.method.set_key = event.download.paused,activations,"pyro.activations.appe
 system.method.set_key = event.download.resumed,activations,"pyro.activations.append=R"
 
 # EVENTS: Timestamp 'tm_downloaded' (time when meta (torrent) file was downloaded)
-method.insert = d.tm_downloaded, simple, "execute.capture=sh,-c,\"echo -n \$(stat -c %Y \\\"$1\\\")\",getDownloadedDate,(d.tied_to_file)"
-method.insert = d.tm_downloaded.set, simple|private, "d.custom.set=tm_downloaded,(cat,(d.tm_downloaded)); d.save_full_session="
-method.set_key = event.download.inserted_new, set_downloaded_date, ((d.tm_downloaded.set))
+method.insert = pyro._tm_downloaded_stat, simple|private, "execute.capture=sh,-c,\"echo -n \$(stat -c %Y \\\"$1\\\")\",getDownloadedDate,(d.tied_to_file)"
+method.insert = pyro._tm_downloaded_init, simple|private, "d.custom.set=tm_downloaded,(cat,(pyro._tm_downloaded_stat)); d.save_full_session="
+method.insert = d.timestamp.downloaded, simple, "d.custom=tm_downloaded"
+method.set_key = event.download.inserted_new, set_downloaded_date, ((pyro._tm_downloaded_init))
 
 # SCHEDULE: Set "last_active" custom field for items that have peers
 system.method.insert = d.last_active, simple|value, "if=$d.peers_connected=,$cat=$system.time=,$d.custom=last_active"

--- a/src/pyrocore/data/config/rtorrent-0.8.6.rc
+++ b/src/pyrocore/data/config/rtorrent-0.8.6.rc
@@ -39,6 +39,11 @@ system.method.insert = pyro.activations.append,simple|private,"d.set_custom=acti
 system.method.set_key = event.download.paused,activations,"pyro.activations.append=P"
 system.method.set_key = event.download.resumed,activations,"pyro.activations.append=R"
 
+# EVENTS: Timestamp 'tm_downloaded' (time when meta (torrent) file was downloaded)
+method.insert = d.tm_downloaded, simple, "execute.capture=sh,-c,\"echo -n \$(stat -c %Y \\\"$1\\\")\",getDownloadedDate,(d.tied_to_file)"
+method.insert = d.tm_downloaded.set, simple|private, "d.custom.set=tm_downloaded,(cat,(d.tm_downloaded)); d.save_full_session="
+method.set_key = event.download.inserted_new, set_downloaded_date, ((d.tm_downloaded.set))
+
 # SCHEDULE: Set "last_active" custom field for items that have peers
 system.method.insert = d.last_active, simple|value, "if=$d.peers_connected=,$cat=$system.time=,$d.custom=last_active"
 schedule = update_last_active,24,42,"d.multicall=started,\"branch=$d.peers_connected=,\\\"d.custom.set=last_active,$cat=$system.time=\\\"\""


### PR DESCRIPTION
Adding ability to use `tm_downloaded` timestamp custom variable in rtorrent config:
- time when meta (torrent) file was downloaded
- requires external `stat` util

I still like this one better then `tm_loaded`.

Note: it uses partly 0.9.6 syntax.

Note2: If you don't like the idea then feel free to reject it.