### PR TITLE
Modify filtering, sorting in rtorrent config

### DIFF
--- a/src/pyrocore/data/config/rtorrent-0.8.6.rc
+++ b/src/pyrocore/data/config/rtorrent-0.8.6.rc
@@ -54,9 +54,11 @@ branch=pyro.extended=,"schedule = bind_rtcontrol,0,0,\"ui.bind_key=download_list
 # UI/VIEW: Show current messages (bound to '!' in rT-PS)
 view_add = messages
 view_filter = messages,d.get_message=
+branch=pyro.extended=,false=,"view_sort_new = messages,less=d.get_message="
+branch=pyro.extended=,"view_sort_new = messages,\"compare=,d.get_message=,d.get_name=\""
 branch=pyro.extended=,false=,"view_sort_current = messages,less=d.get_message="
 branch=pyro.extended=,"view_sort_current = messages,\"compare=,d.get_message=,d.get_name=\""
-system.method.insert = ui.messages.show,simple,"ui.current_view.set=messages ;view_filter=messages,d.get_message= ;view_sort=messages ;print=$view.size=messages,\" message(s)!\""
+system.method.insert = ui.messages.show,simple,"ui.current_view.set=messages ;view_sort=messages ;print=$view.size=messages,\" message(s)!\""
 branch=pyro.extended=,"schedule = bind_messages,0,0,\"ui.bind_key=download_list,!,ui.messages.show=\""
 
 # UI/VIEW: Trackers (all items, sorted by tracker domain and name)


### PR DESCRIPTION
It's not a big issue at all, but since I dig into filtering/sorting in the last couple days ... :)
And it can be useful for newcomers as an example who don't have a clue how these things work (they just copy/paste something and modify the values).

1. Remove filtering from scheduled command when sorting is also used, since sorting triggers filtering as well (it was triggered twice previously).
2. Use `view_sort_new` as well when `view_sort_current` is used (it will deal with newcomers when view isn't switched).