### PR TITLE
Change x_cross_seed_label to source

### DIFF
--- a/src/pyrocore/scripts/mktor.py
+++ b/src/pyrocore/scripts/mktor.py
@@ -142,7 +142,7 @@ class MetafileCreator(ScriptBaseWithConfig):
                     meta["info"]["entropy"] = format(random.getrandbits(self.ENTROPY_BITS),
                                                      'x').zfill(self.ENTROPY_BITS//4)
                 else:
-                    meta["info"]["x_cross_seed_label"] = self.options.cross_seed
+                    meta["info"]["source"] = self.options.cross_seed
             if self.options.no_cross_seed:
                 del meta["info"]["x_cross_seed"]
 


### PR DESCRIPTION
Certain trackers have started checking whether the `source` field is set to a specific value, and if it is not, require you to redownload your torrent files. This changes the `x_cross_seed_label` field to the widely used `source` field.