### PR TITLE
Re-raise SIGINT on Ctrl+C

### DIFF
--- a/src/pyrocore/scripts/base.py
+++ b/src/pyrocore/scripts/base.py
@@ -25,6 +25,7 @@ import glob
 import time
 import errno
 import random
+import signal
 import textwrap
 import logging.config
 from optparse import OptionParser
@@ -282,7 +283,8 @@ class ScriptBase(object):
 
                 sys.stderr.write("\n\nAborted by CTRL-C!\n")
                 sys.stderr.flush()
-                sys.exit(error.EX_TEMPFAIL)
+                signal.signal(signal.SIGINT, signal.SIG_DFL)
+                os.kill(os.getpid(), signal.SIGINT)
             except IOError, exc:
                 # [Errno 32] Broken pipe?
                 if exc.errno == errno.EPIPE:


### PR DESCRIPTION
Without this, if a user does something like:

```bash
for f in movies/*; do mktor "$f" http://example.invalid; done
```

and then tries to cancel it with Ctrl+C, the shell will cancel the current mktor command but continue running the remaining ones in the loop, requiring multiple Ctrl+C's to terminate the loop.

Source: https://www.cons.org/cracauer/sigint.html