### PR TITLE
rtorrent.py: Dedent return so all calls get executed

### DIFF
--- a/src/pyrocore/torrent/rtorrent.py
+++ b/src/pyrocore/torrent/rtorrent.py
@@ -73,7 +73,7 @@ class RtorrentItem(engine.TorrentProxy):
                 result = getattr(namespace, call.lstrip(':'))(*args)
                 if observer:
                     observer(result)
-                return result
+            return result
         except xmlrpc.ERRORS as exc:
             raise error.EngineError("While %s torrent #%s: %s" % (command, self._fields["hash"], exc))
 


### PR DESCRIPTION
_make_it_so in the engine was bugged due to a premature return. It stopped pyrotorque from starting torrents as it would run d.open in the loop and exit before it could run d.start.

Signed-off-by: Gavin Thomas Claugus <gavin@gclaugus.com>